### PR TITLE
Update i2c-bus version to 5.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,13 @@
 # Adafruit I2C LCD Plate
 
-Node.js implementation for the Adafruit RGB 16x2 LCD+Keypad Kit for Raspberry Pi 
+Node.js implementation for the Adafruit RGB 16x2 LCD+Keypad Kit for Raspberry Pi
 http://www.adafruit.com/products/1110
 
-**Note:** This readme is for the current version 1.x.x. If you are using older versions please read the [version 0.0.x readme](https://github.com/fehmer/adafruit-i2c-lcd/tree/0.0.x) or [version 0.1.x readme](https://github.com/fehmer/adafruit-i2c-lcd/tree/0.1.x).
+**Note:** This readme is for the current version 1.x.x/2.x.x. If you are using older versions please read the [version 0.0.x readme](https://github.com/fehmer/adafruit-i2c-lcd/tree/0.0.x) or [version 0.1.x readme](https://github.com/fehmer/adafruit-i2c-lcd/tree/0.1.x).
 
 **Note:** Since version 1.0.0 this module is based on [i2c-bus](https://www.npmjs.com/package/i2c-bus). For compatibility with your node.js version read the i2c-bus documentation. Older versions of this module were based on [i2c](https://www.npmjs.com/package/i2c). adafruit-i2c-lcd version 0.1.x only works with node.js 0.12.x and adafruit-i2c-lcd version 0.0.x only works with node.js 0.10.x.
+
+**Note:** Version 2.0.0 and greater drops support for node v4, v5, and v7 as well as npm < v4 (update npm by running the command ```npm i npm -g```)
 
 **Note:** This module is compatible with  Sainsmart 1602 I2C, see [Compatibility](#compatibility)
 
@@ -45,7 +47,7 @@ lcd.on('button_change', function(button) {
 
 ### LCDPLATE(device:String,address:Number,[pollInterval:Number])
 
-Setting up a new LCDPLATE. 
+Setting up a new LCDPLATE.
 
 - device: Device name, e.g. '/dev/i2c-1'
 - address: Address of the i2c panel, e.g. 0x20
@@ -61,7 +63,7 @@ Close the LCD plate. Use this to stop the polling.
 
 ### LCDPLATE.backlight(color:Number)
 
-Set the backlight of the LCD to the given color. You can use predefined colors from the LCDPLATE class: 
+Set the backlight of the LCD to the given color. You can use predefined colors from the LCDPLATE class:
 
 LCDPLATE.colors = [OFF, RED, GREEN, BLUE, YELLOW, TEAL, VIOLET, WHITE, ON]
 
@@ -99,10 +101,10 @@ Returns the name, e.g. 'SELECT' to a button number. See LCDPLATE.buttons for but
 
 ### button_change
 
-Fires if a button is pressed or released. 
+Fires if a button is pressed or released.
 
 Parameters:   
-    
+
 * button: the button, See LCDPLATE.buttons for button values.
 
 ### Example
@@ -115,10 +117,10 @@ lcd.on('button_change', function(button) {
 
 ### button_up
 
-Fires if a button is released. 
+Fires if a button is released.
 
 Parameters:   
-    
+
 * button: the button, See LCDPLATE.buttons for button values.
 
 
@@ -127,7 +129,7 @@ Parameters:
 Fires if a button is pressed.
 
 Parameters:   
-    
+
 * button: the button, See LCDPLATE.buttons for button values.
 
 ## Compatibility
@@ -153,7 +155,7 @@ Based on the [Adafruit's Raspberry-Pi Python Code Library](https://github.com/ad
 
 >  Here is a growing collection of libraries and example python scripts
 >  for controlling a variety of Adafruit electronics with a Raspberry Pi
-  
+
 >  In progress!
 >
 >  Adafruit invests time and resources providing this open source code,

--- a/example/demo.js
+++ b/example/demo.js
@@ -3,7 +3,7 @@ LCDPLATE = require('adafruit-i2c-lcd').plate;
 lcd = new LCDPLATE(1, 0x20);
 var index = 0;
 
-# create some custom characters
+// create some custom characters
 lcd.createChar(1, [2, 3, 2, 2, 14, 30, 12, 0])
 lcd.createChar(2, [0, 1, 3, 22, 28, 8, 0, 0])
 lcd.createChar(3, [0, 14, 21, 23, 17, 14, 0, 0])

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,40 @@
+{
+  "name": "adafruit-i2c-lcd",
+  "version": "2.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
+    "coffee-script": {
+      "version": "1.12.7",
+      "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.12.7.tgz",
+      "integrity": "sha512-fLeEhqwymYat/MpTPUjSKHVYYl0ec2mOyALEMLmzr5i1isuG+6jfI2j2d5oBO3VIzgUXgBVIcOT9uH1TFxBckw=="
+    },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="
+    },
+    "i2c-bus": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/i2c-bus/-/i2c-bus-5.1.0.tgz",
+      "integrity": "sha512-u/q1fuZ5xrG77y3uo1rAANycboXsRNjneN+6jXRNMT2yRNpanVkbAP+IArwgsPRCHaY/zKxw7x5G8Y2fSPNseA==",
+      "requires": {
+        "bindings": "^1.5.0",
+        "nan": "^2.14.0"
+      }
+    },
+    "nan": {
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
+      "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg=="
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,16 +1,16 @@
 {
   "name": "adafruit-i2c-lcd",
-  "version": "1.0.2",
+  "version": "2.0.0",
   "description": "Node Library for using adafruit i2c rgb lcd pi plate",
   "main": "./lib/index.js",
   "dependencies": {
-    "i2c-bus": "^1.0.2"
+    "i2c-bus": "^5.1.0"
   },
   "devDependencies": {
     "coffee-script": ""
   },
   "scripts": {
-    "prepublish": "node_modules/coffee-script/bin/coffee -o lib -c src"
+    "prepare": "node_modules/coffee-script/bin/coffee -o lib -c src"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
* Updated i2c-bus to 5.1.0 from 1.0.2
* Added package-lock.json
* Fixed unrecognized character in demo (of note, demo won't run directly from this folder, replacing the adafruit-i2c-lcd require with ../lib will run directly from node example/demo)
* i2c-bus 5.1.0 drops support for node v0.10, v0.12, v4, v5, and v7.
* Tested and confirmed support with node js 6, 8, 10, 12
* replaced 'prepublish' command with 'prepare' in package.json scripts. prepublish was deprected. prepare was introduced in npm@4.0.0
* Bumped package version to 2.0.0